### PR TITLE
Compatibility with rocket v5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-session-store"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Aurora Zuoris <programming.aurora@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -12,7 +12,7 @@ keywords = ["rocket", "session", "cookies", "authentication"]
 categories = ["asynchronous", "authentication", "database", "web-programming::http-server"]
 
 [dependencies]
-rocket =  "0.5.0-rc.1"
+rocket =  "0.5.0"
 redis = { version = "0.21.5", optional = true }
 serde = "1.0.134"
 serde_json = "1.0.76"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,32 +11,14 @@ pub mod redis;
 
 use std::time::Duration;
 
-use rand::{
-	rngs::OsRng,
-	Rng,
-};
+use rand::{rngs::OsRng, Rng};
 use rocket::{
-	fairing::{
-		Fairing,
-		Info,
-		Kind,
-	},
-	http::{
-		Cookie,
-		SameSite,
-		Status,
-	},
-	request::{
-		FromRequest,
-		Outcome,
-	},
+	fairing::{Fairing, Info, Kind},
+	http::{Cookie, SameSite, Status},
+	request::{FromRequest, Outcome},
 	response::Responder,
 	tokio::sync::Mutex,
-	Build,
-	Request,
-	Response,
-	Rocket,
-	State,
+	Build, Request, Response, Rocket, State,
 };
 use thiserror::Error;
 
@@ -238,8 +220,8 @@ where
 			let store: &State<SessionStore<T>> = request.guard().await.expect("");
 			let name = store.name.as_str();
 			let cookie = &store.cookie;
-			response.adjoin_header(
-				Cookie::build(name, session.0.as_str())
+			response.adjoin_header::<Cookie>(
+				Cookie::build((name, session.0.as_str()))
 					.http_only(cookie.http_only)
 					.path(
 						cookie
@@ -250,7 +232,7 @@ where
 					)
 					.same_site(cookie.same_site.unwrap_or(SameSite::Lax))
 					.secure(cookie.secure)
-					.finish(),
+					.into(),
 			)
 		}
 	}


### PR DESCRIPTION
Since rocket v5.0 stable is here:
- updated rocket version in Cargo.toml
- made changes, so, lib is compatible with http::cokkie v0.18.0